### PR TITLE
ProvisionedThroughput field may not be present in output from describe-cluster-v2

### DIFF
--- a/mskConfigDetector.py
+++ b/mskConfigDetector.py
@@ -305,16 +305,20 @@ def describeTopic(bootstrapservers,topicname):
 def main():
     #start of storage
     print ("Generating report for " + strClusterarn)
-    storageinfo=response['ClusterInfo']['Provisioned']['BrokerNodeGroupInfo']['StorageInfo']['EbsStorageInfo']['ProvisionedThroughput']
     strStorageMode=response['ClusterInfo']['Provisioned']['StorageMode']
     strClientSubnets=response['ClusterInfo']['Provisioned']['BrokerNodeGroupInfo']['ClientSubnets']
     intNumbAZ=findNumAZ (strClientSubnets)
     strNumberOfBrokerNodes=response['ClusterInfo']['Provisioned']['NumberOfBrokerNodes']
     strClusterName=response['ClusterInfo']['ClusterName']
 
-    strProvisionedThroughput=storageinfo['Enabled']
-    if strProvisionedThroughput==True:
-        strVolumeThroughput=storageinfo['VolumeThroughput']
+    strProvisionedThroughput=False
+
+    # Provisioned storage throughput is optional and can only be enabled using kafka.m5.4xlarge or a larger broker type
+    if 'ProvisionedThroughput' in response['ClusterInfo']['Provisioned']['BrokerNodeGroupInfo']['StorageInfo']['EbsStorageInfo']:
+        storageinfo=response['ClusterInfo']['Provisioned']['BrokerNodeGroupInfo']['StorageInfo']['EbsStorageInfo']['ProvisionedThroughput']
+        strProvisionedThroughput=storageinfo['Enabled']
+        if strProvisionedThroughput==True:
+            strVolumeThroughput=storageinfo['VolumeThroughput']
 
     strInstanceType=response['ClusterInfo']['Provisioned']['BrokerNodeGroupInfo']['InstanceType']
     


### PR DESCRIPTION
Testing this utility against a Provisioned MSK 3 nodes kafka.m5.large cluster will produce following error:

```
sh-5.2$ python3 mskConfigDetector.py
Generating report for arn:aws:kafka:xxx:yyyy:cluster/msk-dev/85e6aad8-56c3-473a-bb04-763e6288c370-6
Traceback (most recent call last):
  File "/home/ssm-user/amazon-msk-config-detector/mskConfigDetector.py", line 473, in <module>
    main()
  File "/home/ssm-user/amazon-msk-config-detector/mskConfigDetector.py", line 308, in main
    storageinfo=response['ClusterInfo']['Provisioned']['BrokerNodeGroupInfo']['StorageInfo']['EbsStorageInfo']['ProvisionedThroughput']
KeyError: 'ProvisionedThroughput'
```

Indeed, the `ProvisionedThroughput` field may not be part of the output of `aws kafka describe-cluster-v2 --cluster-arn <arn>`, for e.g., on my cluster:

```
{
    "ClusterInfo": {
        "ClusterType": "PROVISIONED",
        "ClusterArn": "arn:aws:kafka:xxx:yyyyy:cluster/msk-dev/85e6aad8-56c3-473a-bb04-763e6288c370-6",
        "ClusterName": "msk-dev",
        "CreationTime": "2023-04-26T08:48:06.618000+00:00",
        "CurrentVersion": "KN1VRQENFRJN5",
        "State": "ACTIVE",
        "Tags": {
            "Env": "dev"
        },
        "Provisioned": {
            "BrokerNodeGroupInfo": {
                "BrokerAZDistribution": "DEFAULT",
                "ClientSubnets": [
                    "subnet-09aae13cd98be8206",
                    "subnet-02fbfe16443ab945e",
                    "subnet-0029baf8492f589a2"
                ],
                "InstanceType": "kafka.m5.large",
                "SecurityGroups": [
                    "sg-0b6dbca6cc7cba382"
                ],
                "StorageInfo": {
                    "EbsStorageInfo": {
                        "VolumeSize": 100
                    }
                },
                ...
            },
            ...
    }
}
```

As per AWS MSK console, Provisioned storage throughput is optional and can only be enabled using kafka.m5.4xlarge or a larger broker type.

*Description of changes:*

Changed how `strProvisionedThroughput` is initialized with test to check if `ProvisionedThroughput` is present or not in output from describe- cluster-v2.

