### PR TITLE
StorageMode null return bug fix

### DIFF
--- a/mskConfigDetector.py
+++ b/mskConfigDetector.py
@@ -305,7 +305,10 @@ def describeTopic(bootstrapservers,topicname):
 def main():
     #start of storage
     print ("Generating report for " + strClusterarn)
-    strStorageMode=response['ClusterInfo']['Provisioned']['StorageMode']
+    if 'StorageMode' in response['ClusterInfo']['Provisioned']['BrokerNodeGroupInfo']:
+        strStorageMode=response['ClusterInfo']['Provisioned']['BrokerNodeGroupInfo']['StorageMode']
+    else:
+        strStorageMode="LOCAL"
     strClientSubnets=response['ClusterInfo']['Provisioned']['BrokerNodeGroupInfo']['ClientSubnets']
     intNumbAZ=findNumAZ (strClientSubnets)
     strNumberOfBrokerNodes=response['ClusterInfo']['Provisioned']['NumberOfBrokerNodes']


### PR DESCRIPTION
The describe-cluster-v2 api does not return "StorageMode" under "ClusterInfo" for the non tiered cluster.

*Issue #, if available:*

*Description of changes:*
response['ClusterInfo']['Provisioned']['BrokerNodeGroupInfo']['StorageMode'] on line number 309 returns null for Non tiered cluster(LOCAL). We need to check if the key exists before we reference it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
